### PR TITLE
FIX: correct the location of the bluesky_history.db

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -56,7 +56,7 @@ try:
 except Exception as exc:
     print('local')
     print(exc)
-    RE.md = HistoryDict('{}/.config/blues/bluesky_history.db'.format(str(Path.home())))
+    RE.md = HistoryDict('{}/.config/bluesky/bluesky_history.db'.format(str(Path.home())))
 RE.is_aborted = False
 
 start = timer()


### PR DESCRIPTION
@elistavitski, I accidentally noticed that the location of the `bluesky_history.db` in the `batchdev` branch was mistakenly overwritten by this change https://github.com/NSLS-II-ISS/profile_collection/commit/caf9c4bcaadfc9f1fa03298a6a540c5aa1d5f824#diff-3c9608b12e0317fff31141238965cccfR76. This PR resolves it.