### PR TITLE
FIX: copy-paste-fix set method from nslsii

### DIFF
--- a/startup/22-devices.py
+++ b/startup/22-devices.py
@@ -5,7 +5,8 @@ from nslsii.devices import TwoButtonShutter
 import bluesky.plans as bp
 from ophyd.status import SubscriptionStatus
 print(__file__)
-
+import time
+import datetime
 
 class MFC(Device):
     flow = Cpt(EpicsSignal, '-RB', write_pv='-SP')
@@ -61,7 +62,7 @@ class WPS(Device):
     '''
 
 
-    
+
     lv0 = Cpt(EpicsSignal, '-LV:u0}V-Sense', write_pv='-LV:u0}V-Set')
     lv1 = Cpt(EpicsSignal, '-LV:u1}V-Sense', write_pv='-LV:u1}V-Set')
     lv2 = Cpt(EpicsSignal, '-LV:u2}V-Sense', write_pv='-LV:u2}V-Set')
@@ -95,7 +96,7 @@ class Shutter(Device):
 
     def unsubscribe(self):
         self.function_call = None
-        
+
     def update_state(self, pvname=None, value=None, char_value=None, **kwargs):
         if value == 1:
             self.state = 'closed'
@@ -103,12 +104,12 @@ class Shutter(Device):
             self.state = 'open'
         if self.function_call is not None:
             self.function_call(pvname=pvname, value=value, char_value=char_value, **kwargs)
-        
+
     def open(self):
         print('Opening {}'.format(self.name))
         self.output.put(0)
         self.state = 'open'
-        
+
     def close(self):
         print('Closing {}'.format(self.name))
         self.output.put(1)
@@ -183,12 +184,81 @@ shutter = ShutterMotor(name='User Shutter')
 shutter.shutter_type = 'SP'
 
 
-
 class TwoButtonShutterISS(TwoButtonShutter):
+    RETRY_PERIOD = 1
+
     def stop(self, success=False):
         pass
 
+    def set(self, val):
+        if self._set_st is not None:
+            raise RuntimeError(f'trying to set {self.name}'
+                               ' while a set is in progress')
 
+        cmd_map = {self.open_str: self.open_cmd,
+                   self.close_str: self.close_cmd}
+        target_map = {self.open_str: self.open_val,
+                      self.close_str: self.close_val}
+
+        cmd_sig = cmd_map[val]
+        target_val = target_map[val]
+
+        st = DeviceStatus(self)
+        if self.status.get() == target_val:
+            st._finished()
+            return st
+
+        self._set_st = st
+        print(self.name, val, id(st))
+        # enums = self.status.enum_strs
+
+        def shutter_cb(value, timestamp, **kwargs):
+            # At some point ophyd/pyepics started to do this
+            # remapping before passing to the callbacks so `int` call
+            # here was failing. this means that we were never getting to
+            # the next check which means we were never flipping that status
+            # object to done.
+
+            # value = enums[int(value)]
+            if value == target_val:
+                self._set_st = None
+                self.status.clear_sub(shutter_cb)
+                st._finished()
+
+        # cmd_enums = cmd_sig.enum_strs
+        count = 0
+        _time_fmtstr = '%Y-%m-%d %H:%M:%S'
+
+        def cmd_retry_cb(value, timestamp, **kwargs):
+            nonlocal count
+            # At some point ophyd/pyepics started to do this
+            # remapping before passing to the callbacks so `int` call
+            # here was failing
+            # value = cmd_enums[int(value)]
+            count += 1
+            if count > self.MAX_ATTEMPTS:
+                cmd_sig.clear_sub(cmd_retry_cb)
+                self._set_st = None
+                self.status.clear_sub(shutter_cb)
+                st._finished(success=False)
+            if value == 'None':
+                if not st.done:
+                    time.sleep(self.RETRY_PERIOD)
+                    cmd_sig.set(1)
+
+                    ts = datetime.datetime.fromtimestamp(timestamp) \
+                        .strftime(_time_fmtstr)
+                    if count > 2:
+                        msg = '** ({}) Had to reactuate shutter while {}ing'
+                        print(msg.format(ts, val if val != 'Close'
+                                         else val[:-1]))
+                else:
+                    cmd_sig.clear_sub(cmd_retry_cb)
+
+        cmd_sig.subscribe(cmd_retry_cb, run=False)
+        self.status.subscribe(shutter_cb)
+        cmd_sig.set(1)
+        return st
 
 
 shutter_ph_2b = TwoButtonShutterISS('XF:08IDA-PPS{PSh}', name='shutter_ph_2b')
@@ -323,4 +393,3 @@ pba1.adc7.amp = i0_amp
 pba1.adc1.amp = it_amp
 pba1.adc6.amp = iff_amp
 pba2.adc6.amp = i0_amp
-


### PR DESCRIPTION
At some point the type of the values coming in the callback changed
from the integer values to strings.  This change may have been in
either ophyd or pyepics.

Debugged this on the phone with @elistavitski .