### PR TITLE
Add Hiden RGA as optional detector for step scans

### DIFF
--- a/startup/23-rga.py
+++ b/startup/23-rga.py
@@ -1,0 +1,56 @@
+print(ttime.ctime() + ' >>>> ' + __file__)
+
+from ophyd import Device, Component as Cpt, EpicsSignal, EpicsSignalRO
+
+
+class HidenRGA(Device):
+    """Hiden RGA ophyd device. Reads partial-pressure (MID) values
+    from the caproto IOC and records mass assignments as config."""
+
+    # MID partial-pressure readback PVs (main data signals)
+    mid1  = Cpt(EpicsSignalRO, 'P:MID1-I',  kind='normal', labels={'RGA'})
+    mid2  = Cpt(EpicsSignalRO, 'P:MID2-I',  kind='normal', labels={'RGA'})
+    mid3  = Cpt(EpicsSignalRO, 'P:MID3-I',  kind='normal', labels={'RGA'})
+    mid4  = Cpt(EpicsSignalRO, 'P:MID4-I',  kind='normal', labels={'RGA'})
+    mid5  = Cpt(EpicsSignalRO, 'P:MID5-I',  kind='normal', labels={'RGA'})
+    mid6  = Cpt(EpicsSignalRO, 'P:MID6-I',  kind='normal', labels={'RGA'})
+    mid7  = Cpt(EpicsSignalRO, 'P:MID7-I',  kind='normal', labels={'RGA'})
+    mid8  = Cpt(EpicsSignalRO, 'P:MID8-I',  kind='normal', labels={'RGA'})
+    mid9  = Cpt(EpicsSignalRO, 'P:MID9-I',  kind='normal', labels={'RGA'})
+    mid10 = Cpt(EpicsSignalRO, 'P:MID10-I', kind='normal', labels={'RGA'})
+
+    # Mass config PVs (different prefix, use add_prefix=() for absolute PV names)
+    mass1  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID1',  add_prefix=(), kind='config')
+    mass2  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID2',  add_prefix=(), kind='config')
+    mass3  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID3',  add_prefix=(), kind='config')
+    mass4  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID4',  add_prefix=(), kind='config')
+    mass5  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID5',  add_prefix=(), kind='config')
+    mass6  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID6',  add_prefix=(), kind='config')
+    mass7  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID7',  add_prefix=(), kind='config')
+    mass8  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID8',  add_prefix=(), kind='config')
+    mass9  = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID9',  add_prefix=(), kind='config')
+    mass10 = Cpt(EpicsSignalRO, 'XF:08IDB-VA{RGA:1}Mass:MID10', add_prefix=(), kind='config')
+
+    # Control PVs (omitted from data stream; for programmatic use)
+    open_exp  = Cpt(EpicsSignal, ':OpenExp',  kind='omitted')
+    exp_name  = Cpt(EpicsSignal, ':ExpName',  kind='omitted', string=True)
+    acquire   = Cpt(EpicsSignal, ':Acquire',  kind='omitted')
+    run_exp   = Cpt(EpicsSignal, ':RunExp',   kind='omitted')
+    abort_exp = Cpt(EpicsSignal, ':AbortExp', kind='omitted')
+    close_exp = Cpt(EpicsSignal, ':CloseExp', kind='omitted')
+
+    def read_config_metadata(self):
+        """Return mass-to-channel mapping for scan metadata.
+        Called by get_detector_md() in startup/60-plan_metadata.py."""
+        md = {'device_name': self.name}
+        for i in range(1, 11):
+            md[f'mass{i}'] = getattr(self, f'mass{i}').get()
+        return md
+
+
+try:
+    rga = HidenRGA('XF:08IDB-SE{RGA:1}', name='rga')
+    rga.wait_for_connection(timeout=10)
+except Exception as e:
+    print(f'({ttime.ctime()}) RGA not available: {e}')
+    rga = None

--- a/startup/45-device_dictionaries.py
+++ b/startup/45-device_dictionaries.py
@@ -105,6 +105,13 @@ detector_dictionary =   {
                     'EM I2 V monitor' : {'device' : em_ave, 'channels' : ['em_ave_ch7_mean']},
                     'EM Fluo V monitor' : {'device' : em_ave, 'channels' : ['em_ave_ch8_mean']},
                 }
+
+if rga is not None:
+    detector_dictionary['Hiden RGA'] = {
+        'device': rga,
+        'channels': [f'rga_mid{i}' for i in range(1, 11)],
+    }
+
 # comment
 def get_detector_device_list(key_list, flying=True):
     dets = []


### PR DESCRIPTION
Introduce HidenRGA ophyd device (23-rga.py) wrapping the caproto IOC PVs and register it in detector_dictionary so users can select "Hiden RGA" for step scan data collection into the bluesky event stream.

## No Changes Needed To

- **Scan plans** (67-step_scan_plans.py, 65-fly_scan_plans.py): The step_scan_action_factory checks det.name for known detectors to set exposure times; 'rga' doesn't match any, so it's safely skipped. trigger_and_read() handles it automatically.
- **Metadata** (60-plan_metadata.py): get_detector_md() already calls read_config_metadata() if present.
- **xsample**: Continues using archiver as-is.

## How It Works at Runtime

1. Caproto IOC (cap2.py) must be running with acquisition active
2. User selects "Hiden RGA" in detector list when configuring a step scan
3. At each energy step, trigger_and_read() snapshots rga_mid1 through rga_mid10
4. Mass assignments recorded in run metadata under detectors['Hiden RGA']['config']
5. Data flows: RunEngine → Kafka ("iss" topic) → tiled

## Verification

- Confirm rga.read() returns dict with keys rga_mid1 through rga_mid10 and current float values
- Confirm rga.read_configuration() returns mass values
- Run a test step scan with RGA included: `RE(step_scan_plan(..., detectors=['Hiden RGA', 'I0 ion Chamber'], ...))`
- Verify the run's event data contains rga_mid* columns
- Verify run metadata contains mass assignments