### PR TITLE
🐆 Implement tiled quality-of-service for priority requests

### DIFF
--- a/startup/00-startup.py
+++ b/startup/00-startup.py
@@ -133,6 +133,7 @@ nslsii.configure_base(
      # redis_ssl=True,
 )
 
+db.v2.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 
 logger_db = logging.getLogger('databroker')

--- a/tests/test_analysis_write.py
+++ b/tests/test_analysis_write.py
@@ -57,4 +57,6 @@ for nds in doc_gen:
     todb(*nds)
 
 db_analysis = Broker.named("iss-analysis")
+# Not Critical but since this isn't a workflow it's permitted
+db_analysis.v2.context.http_client.headers['tiled-qos'] = 'acquisition'
 db_analysis.reg.register_handler(ISSANALYSISSPEC, HDF5DFHandler)

--- a/tests/test_iss_run.py
+++ b/tests/test_iss_run.py
@@ -1,5 +1,7 @@
 from databroker import Broker
 db = Broker.named("iss")
+# Not critical, acceptable since this is only a test
+db.v2.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 import sys
 sys.path.insert(0, '/home/xf08id/Repos/workflows')


### PR DESCRIPTION
Tiled recently added a mechanism to ensure that critical path writing requests made during data acquisition go through, while other Prefect workflows that are not as tightly coupled to operations are put on a scheduled queue such that the Tiled servers will be less likely to become saturated / go down / become unavailable e.g.